### PR TITLE
FIX - Jail Feature & Other Improvements

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -70,3 +70,8 @@ JAILED_ROLE_NAME="RoleDisplayName"
 #   If set, the bot will try and clear unused VCs every CLEANUP_DYNAMIC_CHANNELS_FREQUENCY seconds.
 #   If not set, a default value will be used.
 CLEANUP_DYNAMIC_CHANNELS_FREQUENCY="60"
+
+#   The display name of the default Discord Server booster role. Required for the Jail and Unjail features.
+#   If set, the bot will skip this role from deletions and additions.
+#   If not set and the bot uses the jail features, there might be role losses for a member.
+SERVER_BOOSTER_DEFAULT_ROLE_NAME="Server Booster"

--- a/internal/globals/configuration/environment.go
+++ b/internal/globals/configuration/environment.go
@@ -39,3 +39,5 @@ var NotificationChannelsPairs = strings.Split(os.Getenv("NOTIFICATION_CHANNELS")
 var GlobalCommands = strings.Split(os.Getenv("GLOBAL_COMMANDS"), ",")
 
 var JailedRoleName = os.Getenv("JAILED_ROLE_NAME")
+
+var ServerBoosterDefaultRoleName = os.Getenv("SERVER_BOOSTER_DEFAULT_ROLE_NAME")

--- a/internal/services/member/jail.go
+++ b/internal/services/member/jail.go
@@ -55,7 +55,7 @@ func JailMember(s *discordgo.Session, guildId string, userId string, reason stri
 	}
 
 	// Remove all roles from Discord user to restrict access
-	err = RemoveAllDiscordUserRoles(s, guildId, userId)
+	err = RemoveAllDiscordRolesFromMember(s, guildId, userId)
 	if err != nil {
 		fmt.Printf("Failed to JailMember %s (Remove Discord Roles): %v\n", userId, err)
 		return nil, nil, err
@@ -69,7 +69,7 @@ func JailMember(s *discordgo.Session, guildId string, userId string, reason stri
 	}
 
 	// Give designated Jailed Discord role to member
-	err = GiveDiscordRoleToMember(s, guildId, userId, jailRoleName)
+	err = AddDiscordRoleToMember(s, guildId, userId, jailRoleName)
 	if err != nil {
 		fmt.Printf("Failed to JailMember %s (Add Jailee Role): %v\n", userId, err)
 		return nil, nil, err
@@ -139,7 +139,7 @@ func UnjailMember(s *discordgo.Session, guildId string, userId string, jailRoleN
 	}
 
 	// Give roles back to member to return permsisions
-	err = AddRolesToDiscordUser(s, guildId, userId, utils.GetRoleIdsFromRoleString(jailedUser.RoleIdsBeforeJail))
+	err = AddDiscordRolesToMember(s, guildId, userId, utils.GetRoleIdsFromRoleString(jailedUser.RoleIdsBeforeJail))
 	if err != nil {
 		fmt.Printf("Failed to UnjailMember (Add original roles back to Discord user) %s: %v\n", userId, err)
 		return nil, nil, err

--- a/internal/services/member/remote.go
+++ b/internal/services/member/remote.go
@@ -45,7 +45,7 @@ func RemoveAllDiscordRolesFromMember(s *discordgo.Session, guildId string, userI
 			fmt.Printf("Error retrieving role with ID %s: %v\n", roleID, err)
 			return err
 		}
-		if role.Name == "Server Booster" {
+		if role.Name == globalConfiguration.ServerBoosterDefaultRoleName {
 			continue
 		}
 
@@ -63,7 +63,7 @@ func RemoveAllDiscordRolesFromMember(s *discordgo.Session, guildId string, userI
 func RemoveDiscordRoleFromMember(s *discordgo.Session, guildId string, userId string, roleName string) error {
 
 	// 20 Mar 2024: Same Server Booster trick as above
-	if roleName == "Server Booster" {
+	if roleName == globalConfiguration.ServerBoosterDefaultRoleName {
 		return nil
 	}
 
@@ -87,7 +87,7 @@ func RemoveDiscordRoleFromMember(s *discordgo.Session, guildId string, userId st
 func AddDiscordRoleToMember(s *discordgo.Session, guildId string, userId string, roleName string) error {
 
 	// 20 Mar 2024: Same Server Booster trick as above
-	if roleName == "Server Booster" {
+	if roleName == globalConfiguration.ServerBoosterDefaultRoleName {
 		return nil
 	}
 
@@ -119,7 +119,7 @@ func AddDiscordRolesToMember(s *discordgo.Session, guildId string, userId string
 		}
 
 		// 20 Mar 2024: Same Server Booster trick as above
-		if role.DisplayName == "Server Booster" {
+		if role.DisplayName == globalConfiguration.ServerBoosterDefaultRoleName {
 			continue
 		}
 

--- a/internal/services/member/remote.go
+++ b/internal/services/member/remote.go
@@ -37,6 +37,18 @@ func RemoveAllDiscordRolesFromMember(s *discordgo.Session, guildId string, userI
 
 	// Find all user's roles and delete them
 	for _, roleID := range member.Roles {
+
+		// 20 Mar 2024: Discord does not allow any way of removing the default Server Booster role from a guild member
+		// so we just ignore it like it doesn't exist and hope that it goes away. :thumbs_down
+		role, err := s.State.Role(guildId, roleID)
+		if err != nil {
+			fmt.Printf("Error retrieving role with ID %s: %v\n", roleID, err)
+			return err
+		}
+		if role.Name == "Server Booster" {
+			continue
+		}
+
 		err = s.GuildMemberRoleRemove(guildId, userId, roleID)
 		if err != nil {
 			fmt.Printf("Error removing role with ID %s: %v\n", roleID, err)
@@ -49,6 +61,11 @@ func RemoveAllDiscordRolesFromMember(s *discordgo.Session, guildId string, userI
 }
 
 func RemoveDiscordRoleFromMember(s *discordgo.Session, guildId string, userId string, roleName string) error {
+
+	// 20 Mar 2024: Same Server Booster trick as above
+	if roleName == "Server Booster" {
+		return nil
+	}
 
 	// Get the ID of the given role by name
 	discordRoleId := GetDiscordRoleIdForRoleWithName(s, guildId, roleName)
@@ -68,6 +85,11 @@ func RemoveDiscordRoleFromMember(s *discordgo.Session, guildId string, userId st
 }
 
 func AddDiscordRoleToMember(s *discordgo.Session, guildId string, userId string, roleName string) error {
+
+	// 20 Mar 2024: Same Server Booster trick as above
+	if roleName == "Server Booster" {
+		return nil
+	}
 
 	// Get the ID of the given role by name
 	discordRoleId := GetDiscordRoleIdForRoleWithName(s, guildId, roleName)
@@ -95,6 +117,12 @@ func AddDiscordRolesToMember(s *discordgo.Session, guildId string, userId string
 			fmt.Printf("Error ocurred while adding DB roles to Discord member: %v\n", err)
 			return err
 		}
+
+		// 20 Mar 2024: Same Server Booster trick as above
+		if role.DisplayName == "Server Booster" {
+			continue
+		}
+
 		// Get the role ID by display name from Discord
 		discordRoleId := GetDiscordRoleIdForRoleWithName(s, guildId, role.DisplayName)
 		if discordRoleId != nil {

--- a/internal/services/member/remote.go
+++ b/internal/services/member/remote.go
@@ -27,7 +27,7 @@ func IsBot(s *discordgo.Session, guildId string, userId string, debug bool) (*bo
 }
 
 // Removes all roles on the actual Discord member.
-func RemoveAllDiscordUserRoles(s *discordgo.Session, guildId string, userId string) error {
+func RemoveAllDiscordRolesFromMember(s *discordgo.Session, guildId string, userId string) error {
 
 	// Get the member's roles
 	member, err := s.GuildMember(guildId, userId)
@@ -67,7 +67,7 @@ func RemoveDiscordRoleFromMember(s *discordgo.Session, guildId string, userId st
 
 }
 
-func GiveDiscordRoleToMember(s *discordgo.Session, guildId string, userId string, roleName string) error {
+func AddDiscordRoleToMember(s *discordgo.Session, guildId string, userId string, roleName string) error {
 
 	// Get the ID of the given role by name
 	discordRoleId := GetDiscordRoleIdForRoleWithName(s, guildId, roleName)
@@ -86,7 +86,7 @@ func GiveDiscordRoleToMember(s *discordgo.Session, guildId string, userId string
 
 }
 
-func AddRolesToDiscordUser(s *discordgo.Session, guildId string, userId string, roleIds []int) error {
+func AddDiscordRolesToMember(s *discordgo.Session, guildId string, userId string, roleIds []int) error {
 
 	// For each role
 	for _, roleId := range roleIds {

--- a/internal/services/member/roles.go
+++ b/internal/services/member/roles.go
@@ -166,18 +166,18 @@ func DemoteMember(s *discordgo.Session, guildId string, userId string, demoteTyp
 
 	// Update Member in the Discord guild
 	// Remove all roles
-	err = RemoveAllDiscordUserRoles(s, globalConfiguration.DiscordMainGuildId, userId)
+	err = RemoveAllDiscordRolesFromMember(s, globalConfiguration.DiscordMainGuildId, userId)
 	if err != nil {
 		// Revert
 		fmt.Printf("An error ocurred while removing all roles for member: %v\n", err)
-		err = AddRolesToDiscordUser(s, globalConfiguration.DiscordMainGuildId, userId, roleIdsPriorDemote)
+		err = AddDiscordRolesToMember(s, globalConfiguration.DiscordMainGuildId, userId, roleIdsPriorDemote)
 		if err != nil {
 			fmt.Printf("An error ocurred while reverting all roles deletion: %v\n", err)
 		}
 	}
 
 	// Add new roles
-	err = AddRolesToDiscordUser(s, globalConfiguration.DiscordMainGuildId, userId, roleIdsPostDemote)
+	err = AddDiscordRolesToMember(s, globalConfiguration.DiscordMainGuildId, userId, roleIdsPostDemote)
 	if err != nil {
 		fmt.Printf("An error ocurred while adding all roles from DB for member: %v\n", err)
 	}


### PR DESCRIPTION
It seems that Discord does not allow bots to remove or add some default roles like the Server Booster one. Sad times.

So I just skip it from all additions or removals and leave the permissions to the Discord side.