### PR TITLE
REFACTOR - Improve Slash Command Registration Performance

### DIFF
--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -8,7 +8,9 @@ import (
 	"syscall"
 
 	globalConfiguration "github.com/RazvanBerbece/Aztebot/internal/globals/configuration"
+	globalState "github.com/RazvanBerbece/Aztebot/internal/globals/state"
 	slashCommandEvent "github.com/RazvanBerbece/Aztebot/internal/handlers/slashEvents"
+	"github.com/RazvanBerbece/Aztebot/internal/handlers/slashEvents/commands"
 	"github.com/bwmarrin/discordgo"
 )
 
@@ -62,6 +64,8 @@ func (b *DiscordBotBase) AddHandlers(handlers []interface{}) {
 			log.Fatal("Error registering slash commands for AzteBot: ", err)
 		}
 	}
+
+	globalState.AztebotSlashCommands = commands.AztebotSlashCommands
 
 }
 

--- a/internal/base/base.go
+++ b/internal/base/base.go
@@ -53,13 +53,13 @@ func (b *DiscordBotBase) AddHandlers(handlers []interface{}) {
 	// Register slash commands based on app type
 	if globalConfiguration.DiscordMainGuildId != "" {
 		// Register slash commands only for main guild
-		err := slashCommandEvent.RegisterAztebotSlashCommands(b.botSession, true)
+		err := slashCommandEvent.RegisterSlashEventHandlers(b.botSession, true)
 		if err != nil {
 			log.Fatal("Error registering slash commands for AzteBot: ", err)
 		}
 	} else {
 		// Register slash commands for all guilds
-		err := slashCommandEvent.RegisterAztebotSlashCommands(b.botSession, false)
+		err := slashCommandEvent.RegisterSlashEventHandlers(b.botSession, false)
 		if err != nil {
 			log.Fatal("Error registering slash commands for AzteBot: ", err)
 		}

--- a/internal/globals/state/registrations.go
+++ b/internal/globals/state/registrations.go
@@ -2,4 +2,4 @@ package globalState
 
 import "github.com/bwmarrin/discordgo"
 
-var AztebotRegisteredCommands []*discordgo.ApplicationCommand
+var AztebotSlashCommands []*discordgo.ApplicationCommand

--- a/internal/handlers/slashEvents/commands/server/help.go
+++ b/internal/handlers/slashEvents/commands/server/help.go
@@ -36,8 +36,7 @@ func sendHelpGuideToUser(userId string) string {
 		SetColor(000000)
 
 	// Build guide message from all available and registered commands
-	for _, cmd := range globalState.AztebotRegisteredCommands {
-
+	for _, cmd := range globalState.AztebotSlashCommands {
 		title := fmt.Sprintf("`/%s`", cmd.Name)
 		if len(cmd.Options) > 0 {
 			for _, param := range cmd.Options {

--- a/internal/handlers/slashEvents/register.go
+++ b/internal/handlers/slashEvents/register.go
@@ -50,7 +50,7 @@ func RegisterGuildSlashCommands(s *discordgo.Session, appId string, mainGuildOnl
 	if mainGuildOnly {
 		// Register commands only for the main guild
 		// This is more performant when the bot is not supposed to be in more guilds
-		err := RegisterSlashCommandWorker(s, globalConfiguration.DiscordAztebotAppId, *mainGuildId)
+		err := AppCommandCreationWorker(s, globalConfiguration.DiscordAztebotAppId, *mainGuildId)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func RegisterGuildSlashCommands(s *discordgo.Session, appId string, mainGuildOnl
 		// For each guild where the bot exists in, register the available commands
 		guildIds := strings.Fields(globalConfiguration.DiscordGuildIds)
 		for _, guildId := range guildIds {
-			err := RegisterSlashCommandWorker(s, globalConfiguration.DiscordAztebotAppId, guildId)
+			err := AppCommandCreationWorker(s, globalConfiguration.DiscordAztebotAppId, guildId)
 			if err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ func RegisterGuildSlashCommands(s *discordgo.Session, appId string, mainGuildOnl
 	return nil
 }
 
-func RegisterSlashCommandWorker(s *discordgo.Session, appId string, guildId string) error {
+func AppCommandCreationWorker(s *discordgo.Session, appId string, guildId string) error {
 	// A bulk overwrite is desirable as it's preferred to have matching commands between the Discord state and the app code
 	_, err := s.ApplicationCommandBulkOverwrite(appId, guildId, commands.AztebotSlashCommands)
 	if err != nil {

--- a/internal/handlers/slashEvents/register.go
+++ b/internal/handlers/slashEvents/register.go
@@ -10,22 +10,21 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func RegisterAztebotSlashCommands(s *discordgo.Session, mainGuildOnly bool) error {
+func RegisterSlashEventHandlers(s *discordgo.Session, mainGuildOnly bool) error {
 
-	fmt.Printf("[STARTUP] Registering %d slash commands...\n", len(commands.AztebotSlashCommands))
+	fmt.Printf("[STARTUP] Overwriting %d slash commands...\n", len(commands.AztebotSlashCommands))
 
-	// TODO: Optimise this one as it takes ~2 mins to finish executing and it seems to scale poorly with more slash commands
 	err := RegisterGuildSlashCommands(s, globalConfiguration.DiscordAztebotAppId, mainGuildOnly, &globalConfiguration.DiscordMainGuildId)
 	if err != nil {
-		fmt.Printf("error in RegisterGuildSlashCommands: %v\n", err)
+		fmt.Printf("error registering slash event handlers: %v\n", err)
 		return err
 	}
 
 	// Register global commands (available in bot DMs as well)
 	go RegisterDmCommands(s, globalConfiguration.GlobalCommands)
 
-	// Register actual slash command handler
-	go RegisterSlashHandler(s)
+	// Register actual slash command handler - the
+	go AddRegisteredSlashEventHandlers(s)
 
 	return nil
 }

--- a/internal/handlers/slashEvents/slashHandler.go
+++ b/internal/handlers/slashEvents/slashHandler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func RegisterSlashHandler(s *discordgo.Session) {
+func AddRegisteredSlashEventHandlers(s *discordgo.Session) {
 
 	// This handler runs on EVERY slash command registered with the main bot application
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {


### PR DESCRIPTION
- moved away from creating a singular command at a time during registration step and went with a bulk overwrite
  - this is desireable anyway because we want a constant perfect match between the commands defined in code and the ones on the server
  - **_RESULTS!!!_** improved the time to register slash commands at startup for main guild bots by `~99.97%` without losing error handling
- moved guild-specific command registration into its own methods
- other small improvements